### PR TITLE
recording no state region

### DIFF
--- a/heat_demo/heat_demo.py
+++ b/heat_demo/heat_demo.py
@@ -4,7 +4,8 @@ from pacman.model.graphs.machine.impl.machine_vertex import MachineVertex
 from pacman.model.resources.resource_container import ResourceContainer
 from pacman.model.resources.dtcm_resource import DTCMResource
 from pacman.model.resources.sdram_resource import SDRAMResource
-from spinn_front_end_common.abstract_models.abstract_starts_synchronized import AbstractStartsSynchronized
+from spinn_front_end_common.abstract_models.abstract_starts_synchronized \
+    import AbstractStartsSynchronized
 from spinn_front_end_common.abstract_models.abstract_has_associated_binary \
     import AbstractHasAssociatedBinary
 from pacman.model.resources.cpu_cycles_per_tick_resource \
@@ -41,12 +42,13 @@ class HeatDemo(
     def get_binary_file_name(self):
         return "heat_demo.aplx"
 
+    @property
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
         return ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0),
-                iptags=[IPtagResource("localhost", 17894, False, tag=1)])
+            dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+            cpu_cycles=CPUCyclesPerTickResource(0),
+            iptags=[IPtagResource("localhost", 17894, False, tag=1)])
 
 
 def read_output(visualiser, out):

--- a/heat_demo/heat_demo.py
+++ b/heat_demo/heat_demo.py
@@ -1,4 +1,5 @@
 import spinnaker_graph_front_end as g
+from pacman.model.decorators.overrides import overrides
 from pacman.model.graphs.machine.impl.machine_vertex import MachineVertex
 from pacman.model.resources.resource_container import ResourceContainer
 from pacman.model.resources.dtcm_resource import DTCMResource
@@ -34,15 +35,18 @@ class HeatDemo(
     seen_chips = set()
 
     def __init__(self):
-        MachineVertex.__init__(
-            self, ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0),
-                iptags=[IPtagResource("localhost", 17894, False, tag=1)]),
-            label="Tracer")
+        MachineVertex.__init__(self, label="Tracer")
 
+    @overrides(AbstractHasAssociatedBinary.get_binary_file_name)
     def get_binary_file_name(self):
         return "heat_demo.aplx"
+
+    @overrides(MachineVertex.resources_required)
+    def resources_required(self):
+        return ResourceContainer(
+                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+                cpu_cycles=CPUCyclesPerTickResource(0),
+                iptags=[IPtagResource("localhost", 17894, False, tag=1)])
 
 
 def read_output(visualiser, out):

--- a/ray_trace/ray_trace.py
+++ b/ray_trace/ray_trace.py
@@ -1,4 +1,5 @@
 import spinnaker_graph_front_end as g
+from pacman.model.decorators.overrides import overrides
 from pacman.model.graphs.machine.impl.machine_vertex import MachineVertex
 from pacman.model.resources.resource_container import ResourceContainer
 from pacman.model.resources.dtcm_resource import DTCMResource
@@ -35,15 +36,19 @@ class Aggregator(MachineVertex, AbstractHasAssociatedBinary):
 
     def __init__(self):
         MachineVertex.__init__(
-            self, ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0), iptags=[
-                    IPtagResource(".", 17894, strip_sdp=False, tag=1)]),
-            label="Aggregator",
+            self, label="Aggregator",
             constraints=[PlacerChipAndCoreConstraint(0, 0, 1)])
 
+    @overrides(AbstractHasAssociatedBinary.get_binary_file_name)
     def get_binary_file_name(self):
         return "aggregator.aplx"
+
+    @overrides(MachineVertex.resources_required)
+    def resources_required(self):
+        return ResourceContainer(
+                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+                cpu_cycles=CPUCyclesPerTickResource(0), iptags=[
+                    IPtagResource(".", 17894, strip_sdp=False, tag=1)])
 
 
 class Tracer(
@@ -53,13 +58,17 @@ class Tracer(
 
     def __init__(self):
         MachineVertex.__init__(
-            self, ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0)),
-            label="Tracer")
+            self, label="Tracer")
 
+    @overrides(AbstractHasAssociatedBinary.get_binary_file_name)
     def get_binary_file_name(self):
         return "tracer.aplx"
+
+    @overrides(MachineVertex.resources_required)
+    def resources_required(self):
+        return ResourceContainer(
+                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+                cpu_cycles=CPUCyclesPerTickResource(0))
 
 
 def read_output(drawer, out):

--- a/ray_trace/ray_trace.py
+++ b/ray_trace/ray_trace.py
@@ -43,12 +43,13 @@ class Aggregator(MachineVertex, AbstractHasAssociatedBinary):
     def get_binary_file_name(self):
         return "aggregator.aplx"
 
+    @property
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
         return ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0), iptags=[
-                    IPtagResource(".", 17894, strip_sdp=False, tag=1)])
+            dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+            cpu_cycles=CPUCyclesPerTickResource(0), iptags=[
+                IPtagResource(".", 17894, strip_sdp=False, tag=1)])
 
 
 class Tracer(
@@ -64,11 +65,12 @@ class Tracer(
     def get_binary_file_name(self):
         return "tracer.aplx"
 
+    @property
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
         return ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0))
+            dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+            cpu_cycles=CPUCyclesPerTickResource(0))
 
 
 def read_output(drawer, out):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,1 @@
+print "{}_8".format("xxx")


### PR DESCRIPTION
this set of branches works to remove the state region from recording. 

-IntroLab
-PACMAN
-FEC
-SPY
-GFE
-External
- [x] handle python code
- [x] modded the graph to remove resources required issues (nice little refactor)
- [x] handle c code changes
- [x] test basic reads for v (use synfire)
- [x] test basic read for gsyn (use synfire)
- [x] test basic read for spikes (use synfire)
- [x] test multiple reads and writes (use synfire)
- [x] test no reads and writes (use synfire)
- [x] test ssa recording (use synfire)
- [x] test poission recording (used pynn brunnel)
- [x] test poission no recording (use pynn brunnel)
- [x] test auto pause and resume battery of tests
- [x] test with live extraction (is being ignored as auto_pause-and_resume works)
- [x] test reload (use synfire) (has been disabled till a plan of action on it is decided)
