### PR TITLE
New sudoku visualiser

### DIFF
--- a/sudoku/sudoku.py
+++ b/sudoku/sudoku.py
@@ -55,11 +55,16 @@ else:
     vis_exe = ["spynnaker_sudoku"]
     neur_per_num_opt = "--neurons_per_number"
     ms_per_bin_opt = "--ms_per_bin"
-visualiser = subprocess.Popen(
-    args=vis_exe + [neur_per_num_opt, str(neurons_per_digit),
-                    ms_per_bin_opt, str(ms_per_bin)],
-    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
-Thread(target=read_output, args=[visualiser, visualiser.stdout]).start()
+try:
+    visualiser = subprocess.Popen(
+        args=vis_exe + [neur_per_num_opt, str(neurons_per_digit),
+                        ms_per_bin_opt, str(ms_per_bin)],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
+    Thread(target=read_output, args=[visualiser, visualiser.stdout]).start()
+except Exception:
+    print "This example depends on " \
+          "https://github.com/SpiNNakerManchester/sPyNNakerVisualisers"
+    raise
 
 p.setup(timestep=1.0)
 print "Creating Sudoku Network..."

--- a/sudoku/sudoku.py
+++ b/sudoku/sudoku.py
@@ -38,20 +38,32 @@ def read_output(visualiser, out):
 
 
 vis_exe = None
-if sys.platform.startswith("win32"):
-    vis_exe = "sudoku.exe"
-elif sys.platform.startswith("darwin"):
-    vis_exe = "sudoku_osx"
-elif sys.platform.startswith("linux"):
-    vis_exe = "sudoku_linux"
+if "OLD_VIS" in os.environ:
+    if sys.platform.startswith("win32"):
+        vis_exe = "sudoku.exe"
+    elif sys.platform.startswith("darwin"):
+        vis_exe = "sudoku_osx"
+    elif sys.platform.startswith("linux"):
+        vis_exe = "sudoku_linux"
+    else:
+        raise Exception("Unknown platform: {}".format(sys.platform))
+    vis_exe = [os.path.abspath(os.path.join(
+        os.path.dirname(__file__), vis_exe))]
+    neur_per_num_opt = "-neurons_per_number"
+    ms_per_bin_opt = "-ms_per_bin"
 else:
-    raise Exception("Unknown platform: {}".format(sys.platform))
-vis_exe = os.path.abspath(os.path.join(os.path.dirname(__file__), vis_exe))
-print "Executing", vis_exe
-visualiser = subprocess.Popen(args=[
-    vis_exe,
-    "-neurons_per_number", str(neurons_per_digit),
-    "-ms_per_bin", str(ms_per_bin)],
+    visroot = "/Users/dkf/git/sPyNNakerVisualisers"
+    vis_exe = [sys.executable,
+               visroot + "/spynnaker_visualisers/sudoku/sudoku_visualiser.py"]
+    neur_per_num_opt = "--neurons_per_number"
+    ms_per_bin_opt = "--ms_per_bin"
+    if "PYTHONPATH" in os.environ:
+        os.environ["PYTHONPATH"] += ":" +visroot
+    else:
+        os.environ["PYTHONPATH"] = visroot
+visualiser = subprocess.Popen(
+    args=vis_exe + [neur_per_num_opt, str(neurons_per_digit),
+                    ms_per_bin_opt, str(ms_per_bin)],
     stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
 Thread(target=read_output, args=[visualiser, visualiser.stdout]).start()
 

--- a/sudoku/sudoku.py
+++ b/sudoku/sudoku.py
@@ -62,8 +62,9 @@ def activate_visulaser(old_vis):
             args=vis_exe + [neur_per_num_opt, str(neurons_per_digit),
                             ms_per_bin_opt, str(ms_per_bin)],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
-        Thread(target=read_output, args=[visualiser, visualiser.stdout]).start()
-    except Exception as ex:
+        Thread(target=read_output,
+               args=[visualiser, visualiser.stdout]).start()
+    except Exception:
         if not old_vis:
             print "This example depends on " \
                   "https://github.com/SpiNNakerManchester/sPyNNakerVisualisers"

--- a/sudoku/sudoku.py
+++ b/sudoku/sudoku.py
@@ -52,15 +52,9 @@ if "OLD_VIS" in os.environ:
     neur_per_num_opt = "-neurons_per_number"
     ms_per_bin_opt = "-ms_per_bin"
 else:
-    visroot = "/Users/dkf/git/sPyNNakerVisualisers"
-    vis_exe = [sys.executable,
-               visroot + "/spynnaker_visualisers/sudoku/sudoku_visualiser.py"]
+    vis_exe = ["spynnaker_sudoku"]
     neur_per_num_opt = "--neurons_per_number"
     ms_per_bin_opt = "--ms_per_bin"
-    if "PYTHONPATH" in os.environ:
-        os.environ["PYTHONPATH"] += ":" +visroot
-    else:
-        os.environ["PYTHONPATH"] = visroot
 visualiser = subprocess.Popen(
     args=vis_exe + [neur_per_num_opt, str(neurons_per_digit),
                     ms_per_bin_opt, str(ms_per_bin)],

--- a/sudoku/sudoku.py
+++ b/sudoku/sudoku.py
@@ -14,6 +14,7 @@ import subprocess
 from threading import Thread
 import os
 import sys
+import traceback
 
 run_time = 20000                        # run time in milliseconds
 neurons_per_digit = 5                   # number of neurons per digit
@@ -37,34 +38,43 @@ def read_output(visualiser, out):
     os._exit(0)
 
 
-vis_exe = None
-if "OLD_VIS" in os.environ:
-    if sys.platform.startswith("win32"):
-        vis_exe = "sudoku.exe"
-    elif sys.platform.startswith("darwin"):
-        vis_exe = "sudoku_osx"
-    elif sys.platform.startswith("linux"):
-        vis_exe = "sudoku_linux"
+def activate_visulaser(old_vis):
+    vis_exe = None
+    if old_vis:
+        if sys.platform.startswith("win32"):
+            vis_exe = "sudoku.exe"
+        elif sys.platform.startswith("darwin"):
+            vis_exe = "sudoku_osx"
+        elif sys.platform.startswith("linux"):
+            vis_exe = "sudoku_linux"
+        else:
+            raise Exception("Unknown platform: {}".format(sys.platform))
+        vis_exe = [os.path.abspath(os.path.join(
+            os.path.dirname(__file__), vis_exe))]
+        neur_per_num_opt = "-neurons_per_number"
+        ms_per_bin_opt = "-ms_per_bin"
     else:
-        raise Exception("Unknown platform: {}".format(sys.platform))
-    vis_exe = [os.path.abspath(os.path.join(
-        os.path.dirname(__file__), vis_exe))]
-    neur_per_num_opt = "-neurons_per_number"
-    ms_per_bin_opt = "-ms_per_bin"
-else:
-    vis_exe = ["spynnaker_sudoku"]
-    neur_per_num_opt = "--neurons_per_number"
-    ms_per_bin_opt = "--ms_per_bin"
-try:
-    visualiser = subprocess.Popen(
-        args=vis_exe + [neur_per_num_opt, str(neurons_per_digit),
-                        ms_per_bin_opt, str(ms_per_bin)],
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
-    Thread(target=read_output, args=[visualiser, visualiser.stdout]).start()
-except Exception:
-    print "This example depends on " \
-          "https://github.com/SpiNNakerManchester/sPyNNakerVisualisers"
-    raise
+        vis_exe = ["spynnaker_sudoku"]
+        neur_per_num_opt = "--neurons_per_number"
+        ms_per_bin_opt = "--ms_per_bin"
+    try:
+        visualiser = subprocess.Popen(
+            args=vis_exe + [neur_per_num_opt, str(neurons_per_digit),
+                            ms_per_bin_opt, str(ms_per_bin)],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
+        Thread(target=read_output, args=[visualiser, visualiser.stdout]).start()
+    except Exception as ex:
+        if not old_vis:
+            print "This example depends on " \
+                  "https://github.com/SpiNNakerManchester/sPyNNakerVisualisers"
+            traceback.print_exc()
+            print "trying old visuliser"
+            activate_visulaser(old_vis=True)
+        else:
+            raise
+
+
+activate_visulaser(old_vis=("OLD_VIS" in os.environ))
 
 p.setup(timestep=1.0)
 print "Creating Sudoku Network..."


### PR DESCRIPTION
This allows the new visualiser to be used so long as the `sPyNNakerVisualisers` package has been `pip install`ed. The old visualiser can be used instead by setting the `OLD_VIS` environment variable (to anything) before running the sudoku script.