### PR TITLE
Matplotlib after our installs

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - name: Checkout

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -40,8 +40,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install pip, etc
       uses: ./support/actions/python-tools
-    - name: Install matplotlib
-      uses: ./support/actions/install-matplotlib
     - name: Install Spinnaker Dependencies
       uses: ./support/actions/checkout-spinn-deps
       with:
@@ -49,6 +47,8 @@ jobs:
           SpiNNUtils SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
           SpiNNFrontEndCommon sPyNNaker sPyNNaker8
         install: true
+    - name: Install matplotlib
+      uses: ./support/actions/install-matplotlib
 
     - name: Lint with flake8
       run: flake8 balanced_random learning sudoku synfire

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This brings the .github/workflows/python_actions.yml in line with all others.

python 3.6 is hard to test due to number of dependencies that stopped supporting it.
For example matplotlib!

Installing matplotlib must happen after spinnaker install so we can cap numpy.
See: https://github.com/SpiNNakerManchester/IntroLab/actions/runs/2148964882



